### PR TITLE
fix(requirements): Remove psycopg2 from requirements     

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 $ pip install graphene-gis
 ```
 
+Make sure that you have appropriate driver to interact with postgis-- `psycopg2` or
+`psycopg2-binary`. The binary package is a practical choice for development and testing
+but in production it is advised to use the package built from sources. More info [here](https://www.psycopg.org/articles/2018/02/08/psycopg-274-released/).
+
 Add it to your `INSTALLED_APPS` in `settings.py`:
 
 ```python

--- a/graphene_gis/scalars.py
+++ b/graphene_gis/scalars.py
@@ -1,3 +1,4 @@
+import json
 from graphql.language import ast
 from graphene.types import Scalar
 from django.contrib.gis.geos import GEOSGeometry
@@ -13,18 +14,18 @@ class GISScalar(Scalar):
 
     @staticmethod
     def serialize(geometry):
-        return eval(geometry.geojson)
+        return json.loads(geometry.geojson)
 
     @classmethod
     def parse_literal(cls, node):
         assert isinstance(node, ast.StringValue)
         geometry = GEOSGeometry(node.value)
-        return eval(geometry.geojson)
+        return json.loads(geometry.geojson)
 
     @classmethod
     def parse_value(cls, node):
         geometry = GEOSGeometry(node.value)
-        return eval(geometry.geojson)
+        return json.loads(geometry.geojson)
 
 
 class JSONScalar(Scalar):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         "graphene>=2.1,<3",
         "graphene-django>=2.5,<3",
         "graphql-core>=2.1,<3",
-        "psycopg2>=2.8,<3"
     ],
 
     setup_requires=["pytest-runner"],


### PR DESCRIPTION
`graphene-gis` should not force the developers hand on which `postgres` driver to use.

psycopg2: Requires postgres to be installed on the system. I would never recommend installing a DB for testing a lib, or even while developing onto your system without using containers.

psycopg2-binary: The binary package is a practical choice for development and testing but in production it is advised to use the package built from sources.

More info [here](https://www.psycopg.org/articles/2018/02/08/psycopg-274-released/).

This is why, after careful deliberation, we have decided to omit this package from `graphene-gis`'s requirements.

Issue https://github.com/EverWinter23/graphene-gis/issues/4
Issue https://github.com/EverWinter23/graphene-gis/issues/3

Credits:
@kevindice has helped in uncovering the fundamental issue.
@asalmoqbel has helped us in arriving at this decision by raising sound arguments against it's [exclusion](https://github.com/EverWinter23/graphene-gis/issues/3#issuecomment-754538261). 

Thanks! @kevindice, if you could review the MR, that would be great. This fix will be merged and released as `v0.0.6`.