### PR TITLE
fix: GISScalar query variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ $ python setup.py sdist
 $ twine upload dist/*
 ```
 
+### UPDATE
+
+Targeting graphene-v3 update by March'22.
+
 ### LICENSE [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 This code falls under the MIT license which permits the reuse of the proprietary software provided that all copies of the licensed software include a copy of the MIT License terms and the copyright notice. Go crazy!

--- a/graphene_gis/scalars.py
+++ b/graphene_gis/scalars.py
@@ -24,7 +24,7 @@ class GISScalar(Scalar):
 
     @classmethod
     def parse_value(cls, node):
-        geometry = GEOSGeometry(node.value)
+        geometry = GEOSGeometry(node)
         return json.loads(geometry.geojson)
 
 

--- a/graphene_gis/tests/test_query.py
+++ b/graphene_gis/tests/test_query.py
@@ -1,6 +1,9 @@
 import json
+
 import graphene
+from django.contrib.gis.geos import GEOSGeometry
 from graphene_gis.converter import gis_converter  # noqa
+from graphene_gis.scalars import PointScalar
 from graphene_gis.tests.mocks import PointModel, PointModelType
 
 
@@ -67,5 +70,86 @@ def test_should_convert_json_to_dict():
     }
 
     result = schema.execute(query)
+    assert not result.errors
+    assert json.loads(json.dumps(dict(result.data))) == expected
+
+
+"""
+NOTE: Refer https://github.com/EverWinter23/graphene-gis/issues/9
+Some evasive issue. I wouldn't reccomend using the following for
+implementing mutations, because it involves some unecessary steps.
+
+The converter will convert the WKT geometry to geojson, which you'll
+have to convert back to WKT using GEOSGeometry to initialize the object.
+
+It's way simple rather use the graphene.String for the input argument for 
+WKT inputs. This is demonstarted in the next test case.
+"""
+def test_scalar_query_variables():
+    class Query(graphene.ObjectType):
+        point_model = graphene.Field(PointModelType, location=PointScalar(required=True))
+
+        def resolve_point_model(self, info, location):
+            return PointModel(location=GEOSGeometry(f"{location}"), props={"type": "Feature"})
+
+    schema = graphene.Schema(query=Query)
+
+    query = """
+        query TestQuery($location: PointScalar!) {
+            pointModel(location: $location) {
+                location
+                props
+            }
+        }
+    """
+
+    expected = {
+        "pointModel": {
+            "location": {
+                "type": "Point",
+                "coordinates": [42.0, 15.0]
+            },
+            "props": {
+                "type": "Feature"
+            }
+        }
+    }
+
+    result = schema.execute(query, variables={"location": "POINT(42.0 15.0)"})
+    assert not result.errors
+    assert json.loads(json.dumps(dict(result.data))) == expected
+
+
+def test_native_query_variables():
+    class Query(graphene.ObjectType):
+        point_model = graphene.Field(PointModelType, location=graphene.String(required=True))
+
+        def resolve_point_model(self, info, location):
+            return PointModel(location=location, props={"type": "Feature"})
+
+    schema = graphene.Schema(query=Query)
+
+    query = """
+        query TestQuery($location: String!) {
+            pointModel(location: $location) {
+                location
+                props
+            }
+        }
+    """
+
+    expected = {
+        "pointModel": {
+            "location": {
+                "type": "Point",
+                "coordinates": [42.0, 15.0]
+            },
+            "props": {
+                "type": "Feature"
+            }
+        }
+    }
+
+    result = schema.execute(query, variables={"location": "POINT(42.0 15.0)"})
     assert not result.errors
     assert json.loads(json.dumps(dict(result.data))) == expected


### PR DESCRIPTION
There was an issue when using query variables and WKT input. While parsing the input value, it would look for node.value which would be null for a string.

Remedied that. On another note, these two lines were not being covered by any test case and were reported as line misses by pytest-cov which ultimately was the root of this evil. We're still missing 100% code-cov by 2 lines, but that's a story for another day.

Thanks to Dimitri Gnidash for identifying the root cause and identification of the solution.

Fixes: https://github.com/EverWinter23/graphene-gis/issues/9